### PR TITLE
Fix getting nodeid: iterate trough subjobs to get ResourceID

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_node_v3.go
@@ -315,7 +315,14 @@ func resourceCCENodeV3Create(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error fetching opentelekomcloud Job Details: %s", err)
 	}
-	nodeid := subjob.Spec.SubJobs[0].Spec.ResourceID
+
+	var nodeid string
+	for _, s := range subjob.Spec.SubJobs {
+		if s.Spec.Type == "CreateNodeVM" {
+			nodeid = s.Spec.ResourceID
+			break
+		}
+	}
 
 	log.Printf("[DEBUG] Waiting for CCE Node (%s) to become available", s.Metadata.Name)
 	stateConf := &resource.StateChangeConf{


### PR DESCRIPTION
Accessing `subjob.Spec.SubJobs[0]` might not work if ResourceID not in element[0]